### PR TITLE
Change text response to JSON format

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -11,6 +11,7 @@ import { default as session } from 'express-session';
 import { default as oauthRouter } from './oauth2/oauth2.routes';
 import { default as wellKnownRouter } from './certs/certs.routes';
 import { errorHandler } from './utils/error.handler';
+import { log, parseLogData, LOG_LEVEL } from './utils/logger';
 import config from './config';
 
 const app = express();
@@ -52,5 +53,20 @@ app.use(errorHandler);
 
 // Health check for Load Balancer
 app.get('/health', (req, res) => res.send('alive'));
+
+// Handling all unknown route request with 404
+app.all('*', (req, res) => {
+  log(
+    LOG_LEVEL.INFO,
+    parseLogData(
+      'Unknown Route Request',
+      `Received from ${req.headers['x-forwarded-for']}, Operation - ${req.method}. ${'\r\n'
+      }Route Name: ${req.originalUrl}`,
+      404,
+      null,
+    ),
+  );
+  res.status(404).send({ message: `Page not found` });
+});
 
 export default app;

--- a/src/oauth2/management/management.routes.ts
+++ b/src/oauth2/management/management.routes.ts
@@ -1,6 +1,6 @@
 // management.routes
 
-import { Router, Request, Response } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import passport from 'passport';
 import config from '../../config';
 import { ManagementController } from './management.controller';
@@ -14,14 +14,29 @@ import { LOG_LEVEL, log, parseLogData } from '../../utils/logger';
  * The first restrict only the client manager.
  * The seconds restrict the client manager and also the registration token of the client.
  */
-const authenticateMiddleware = passport.authenticate(
-  config.CLIENT_MANAGER_PASSPORT_STRATEGY,
-  { session: false, failWithError: true, failureMessage: true },
-);
-const authenticateManagementMiddleware = passport.authenticate(
-  config.CLIENT_MANAGER_PASSPORT_MANAGEMENT_STRATEGY,
-  { session: false, failWithError: true, failureMessage: true },
-);
+const authenticateMiddleware =
+  function (req: Request, res: Response, next: NextFunction) {
+    const passportCallback = Wrapper.wrapPassportCallback(req, res, next);
+    return (
+      passport.authenticate(
+        config.CLIENT_MANAGER_PASSPORT_STRATEGY,
+        { session: false, failWithError: true, failureMessage: true },
+        passportCallback,
+      )(req, res, next)
+    );
+  };
+
+const authenticateManagementMiddleware =
+  function (req: Request, res: Response, next: NextFunction) {
+    const passportCallback = Wrapper.wrapPassportCallback(req, res, next);
+    return (
+      passport.authenticate(
+        config.CLIENT_MANAGER_PASSPORT_MANAGEMENT_STRATEGY,
+        { session: false, failWithError: true, failureMessage: true },
+        passportCallback,
+      )(req, res, next)
+    );
+  };
 
 export const errorMessages = {
   MISSING_CLIENT_INFORMATION: 'Client information parameter is missing',

--- a/src/oauth2/oauth2.controller.ts
+++ b/src/oauth2/oauth2.controller.ts
@@ -22,6 +22,7 @@ import config from '../config';
 import { BadRequest } from '../utils/error';
 import { LOG_LEVEL, log, parseLogData } from '../utils/logger';
 import { ScopeUtils } from '../scope/scope.utils';
+import { Wrapper } from '../utils/wrapper';
 
 // Error messages
 export const errorMessages = {
@@ -558,7 +559,16 @@ export const decisionEndpoint = [
  * authenticate when making requests to this endpoint.
  */
 export const tokenEndpoint = [
-  passport.authenticate(['basic', 'oauth2-client-password'], { session: false }),
+  function (req: Request, res: Response, next: NextFunction) {
+    const passportCallback = Wrapper.wrapPassportCallback(req, res, next);
+    return (
+      passport.authenticate(
+        ['basic', 'oauth2-client-password'],
+        { session: false },
+        passportCallback,
+      )(req, res, next)
+    );
+  },
   server.token(),
 ];
 
@@ -570,7 +580,16 @@ export const tokenEndpoint = [
  * more information in @see https://tools.ietf.org/html/rfc7662
  */
 export const tokenIntrospectionEndpoint = [
-  passport.authenticate(['basic', 'oauth2-client-password'], { session: false }),
+  function (req: Request, res: Response, next: NextFunction) {
+    const passportCallback = Wrapper.wrapPassportCallback(req, res, next);
+    return (
+      passport.authenticate(
+        ['basic', 'oauth2-client-password'],
+        { session: false },
+        passportCallback,
+      )(req, res, next)
+    );
+  },
   async (req: Request, res: Response, next: NextFunction) => {
     const token = req.body.token;
 

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -38,6 +38,12 @@ export class BadRequest extends BaseError {
   }
 }
 
+export class Unauthorized extends BaseError {
+  constructor(message?: string) {
+    super(message || 'Unauthorized', 401);
+  }
+}
+
 export class InternalServerError extends BaseError {
   constructor(message?: string) {
     super(message || 'Internal Server Error', 500);

--- a/src/utils/wrapper.ts
+++ b/src/utils/wrapper.ts
@@ -1,6 +1,7 @@
 // wrapper
 
 import { Response, Request, NextFunction } from 'express';
+import { Unauthorized } from './error';
 
 export class Wrapper {
 
@@ -11,6 +12,28 @@ export class Wrapper {
   static wrapAsync(func: any) {
     return (req: Request, res: Response, next: NextFunction) => {
       func(req, res, next).catch((err: Error) => next(err));
+    };
+  }
+
+  /**
+   * Creates wrapper function for passport authenticate callback function
+   * @param req - Request object
+   * @param res - Response object
+   * @param next - Next function
+   */
+  static wrapPassportCallback(req: Request, res: Response, next: NextFunction) {
+    return function (error: any, user: any) {
+
+      if (error) {
+        return next(new Unauthorized());
+      }
+
+      if (!user) {
+        return next(new Unauthorized());
+      }
+
+      req.user = user;
+      next();
     };
   }
 }


### PR DESCRIPTION
Adding passport wrapper for callback function received in `passport.authenticate` for changing the `unauthorized` text message to JSON .

 Also add not found route handling for changing the`Cannot XXX XXX/XXX` text response to `Page not found` in JSON response.